### PR TITLE
changed engine to node >= 8 as it is still in LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Lloyd Hilaiel (http://lloyd.io)",
   "engines": {
-    "node": ">= 9"
+    "node": ">= 8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As you can see on this [nodejs github page](https://github.com/nodejs/Release), version 8 is still Active LTS until April 2019.